### PR TITLE
[hot-fix] : Replace the .env by .env.example

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-PORT=3000
-# To use on localhost
-#MONGO_LOCAL_URI=mongodb://localhost:27017/ipssi_timer
-MONGO_ATLAS_URI=mongodb+srv://mountakha:tXViwR8JoJAGYOpu@cluster0-8jeae.mongodb.net/test?retryWrites=true
-MONGO_LOCAL_URI=mongodb://mongo:27017/ipssi_timer
-
-#tXViwR8JoJAGYOpu

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+PORT=8080
+# To use on localhost
+MONGO_LOCAL_URI=mongodb://localhost:27017/<database_name>
+# To use when you use MongoDB Atlas cloud Database services
+MONGO_ATLAS_URI=mongodb+srv://<username>:<password>@cluster0-8jeae.mongodb.net/test?retryWrites=true
+# To use on localhost with Docker
+MONGO_LOCAL_URI=mongodb://mongo:27017/<database_name>


### PR DESCRIPTION
**Reason: Because it contains sensitive informations**